### PR TITLE
Support for remote hosts

### DIFF
--- a/group_vars/kali/vars.yml
+++ b/group_vars/kali/vars.yml
@@ -1,4 +1,7 @@
 ---
+# Set as the user account that runs the ansible playbook
+kali_user: "{{ lookup('env','USER') }}"
+
 # Burp Suite settings
 burpsuite_cacert_path: "{{ burpsuite_extras_dir }}/PortSwigger_CA.der"
 burpsuite_extras_dir: "/home/{{ kali_user }}/BurpSuiteExtras"
@@ -44,9 +47,6 @@ kali_packages:
   - wireguard
   - xclip
   - xsel
-
-# Set as the user account that runs the ansible playbook
-kali_user: "{{ lookup('env','USER') }}"
 
 misc_downloads:
   - url: https://github.com/DominicBreuker/pspy/releases/download/v1.2.0/pspy64

--- a/inventory
+++ b/inventory
@@ -1,2 +1,5 @@
+#[kali]
+#localhost ansible_connection=local ansible_python_interpreter=python3
+
 [kali]
-localhost ansible_connection=local ansible_python_interpreter=python3
+192.168.1.165 ansible_connection=ssh ansible_python_interpreter=python3 ansible_user=kali

--- a/kali-personalize.yml
+++ b/kali-personalize.yml
@@ -43,7 +43,7 @@
       register: firefox_profile
 
     - name: Create FireFox default profile
-      ansible.builtin.command: "firefox-esr -CreateProfile \"hacker {{ firefox_default_profile_dir }}\""
+      ansible.builtin.command: "firefox-esr -headless -CreateProfile \"hacker {{ firefox_default_profile_dir }}\""
       when: not firefox_profile.stat.exists
 
     - name: Copy Firefox ini files

--- a/main.yml
+++ b/main.yml
@@ -22,7 +22,8 @@
 
         - name: Set kali_user fact
           ansible.builtin.set_fact:
-            kali_user: "{{ _kali_user_choice.user_input | default(kali_user) }}"
+            kali_user: "{{ _kali_user_choice.user_input }}"
+          when: '_kali_user_choice.user_input != ""'
       when: not config_yml.stat.exists
 
     - name: Get user details

--- a/main.yml
+++ b/main.yml
@@ -5,20 +5,30 @@
     burpsuite_products_map:
       - { name: Burp Suite Community, alias: community }
       - { name: Burp Suite Professional, alias: pro }
+
   tasks:
+
+    - name: Check if host config exists
+      delegate_to: localhost
+      ansible.builtin.stat:
+        path: "host_vars/{{ ansible_facts['default_ipv4']['address'] }}/vars.yml"
+      register: config_yml
+
+    - block:
+        - name: Kali user prompt
+          ansible.builtin.pause:
+            prompt: Enter the username you want to use on kali (default {{ kali_user }})?
+          register: _kali_user_choice
+
+        - name: Set kali_user fact
+          ansible.builtin.set_fact:
+            kali_user: "{{ _kali_user_choice.user_input | default(kali_user) }}"
+      when: not config_yml.stat.exists
+
     - name: Get user details
       user:
         name: "{{ kali_user }}"
       register: kali_user_details
-
-    - name: Check if .a4k_config.yml exists
-      ansible.builtin.stat:
-        path: "{{ kali_user_details.home }}/.a4k_config.yml"
-      register: config_yml
-
-    - name: Load .a4k_config.yml
-      ansible.builtin.include_vars: "{{ kali_user_details.home }}/.a4k_config.yml"
-      when: config_yml.stat.exists
 
     - block:
         - name: Burp Suite edition prompt
@@ -56,10 +66,17 @@
         - 'burpsuite_product_type == "pro"'
         - 'not check_burpsuitepro_licensed.stat.exists'
 
+    - name: Create host config directory
+      delegate_to: localhost
+      file:
+        path: "host_vars/{{ ansible_facts['default_ipv4']['address'] }}"
+        state: directory
+
     - name: Save config
+      delegate_to: localhost
       ansible.builtin.template:
         src: templates/config/config.yml.j2
-        dest: "{{ kali_user_details.home }}/.a4k_config.yml"
+        dest: "host_vars/{{ ansible_facts['default_ipv4']['address'] }}/vars.yml"
         mode: 0600
 
 - name: Include Kali packages playbook

--- a/templates/config/config.yml.j2
+++ b/templates/config/config.yml.j2
@@ -1,3 +1,6 @@
 ---
 # Configuration for ansible-playbook-kali
+# Product type: community or pro
 burpsuite_product_type: {{ burpsuite_product_type }}
+# Kali user
+kali_user: {{ kali_user }}


### PR DESCRIPTION
- Changed remote .a4k_config by local configurations on host_vars/x/vars.yml
- Added kali_user config option by host
- Flag in firefox installation to not require graphical DISPLAY

